### PR TITLE
Fix chevron card component text/chevron alignment:

### DIFF
--- a/src/lib/components/shared/ChevronCard.svelte
+++ b/src/lib/components/shared/ChevronCard.svelte
@@ -10,19 +10,24 @@
 	<div>
 		<h3>
 			<a href={chevronData.web_url} class="chevron-card">{chevronData.heading}</a>
-			<p>{chevronData.content}</p>
 		</h3>
+		<p>{chevronData.content}</p>
 	</div>
 </li>
 
 <style>
 	div {
-		padding: 10px 10px;
+		padding-top: 10px;
+		padding-bottom: 10px;
 		position: relative;
 	}
 
 	p {
 		font-weight: normal;
+	}
+
+	h3 {
+		margin-bottom: 10px;
 	}
 
 	li {
@@ -41,7 +46,7 @@
 		content: '';
 		display: block;
 		height: 7px;
-		right: 0px;
+		right: 2px;
 		top: 16px;
 		position: absolute;
 		transform: translateY(0px) rotate(45deg) scale(1);


### PR DESCRIPTION
Fix text and chevron alignment in Chevron Card Component:    

- Remove `padding-left` and `padding-right` from chevron card wrapper div to correctly left align text flush with the edge of the chevron card
- Manually adjust right property pixel value of the chevron `::before` pseudo-element to correctly align it to right edge of chevron card wrapper (see screenshot with debug lines to view alignment)
- Change p element from being child of `h3` element to sibling of `h3` element
- Add `margin-bottom` to `h3` element to space `h3` from `p` tag correctly

Before change:

![Screenshot 2023-08-10 at 15 10 15](https://github.com/alphagov/learningtime-hh-sem2-gov-uk-home-page-in-svelte/assets/79383398/ed512275-a582-44e3-8d8e-40cc33b53c21)

After change:

![Screenshot 2023-08-10 at 15 10 32](https://github.com/alphagov/learningtime-hh-sem2-gov-uk-home-page-in-svelte/assets/79383398/2df2645d-282e-4e9f-bc4b-c54fabeb47e0)

Chevron pseudo-element alignment better visualised with debug lines:

![Screenshot 2023-08-10 at 15 11 04](https://github.com/alphagov/learningtime-hh-sem2-gov-uk-home-page-in-svelte/assets/79383398/9f31d8dd-a4bb-475d-836d-19fef80c8d73)
