### PR TITLE
#19/create resuable link classes

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -77,8 +77,7 @@ h2 {
 	font-size: 24px;
 }
 
-p,
-a {
+p {
 	font-size: 16px;
 }
 
@@ -92,8 +91,77 @@ a {
 		font-size: 32px;
 	}
 
-	p,
-	a {
+	p {
 		font-size: 19px;
 	}
+}
+
+/* Links */
+
+/* Link font styles */
+
+.link--bold {
+	font-weight: bold;
+}
+
+.link--small {
+	font-size: 14px;
+}
+
+.link--medium {
+	font-size: 16px;
+}
+
+.link--large {
+	font-size: 18px;
+}
+
+@media screen and (min-width: 600px) {
+
+	.link--small {
+		font-size: 16px;
+	}
+
+	.link--medium {
+		font-size: 19px;
+	}
+
+	.link--large {
+		font-size: 24px;
+	}
+
+}
+
+/* Link pseudo-classes */
+
+.link-effects:link {
+	color: var(--govuk-blue);
+}
+
+.link-effects:active {
+	color: var(--govuk-black)
+}
+
+.link-effects:hover {
+	text-decoration-thickness: max(3px, .1875rem, .12em);
+	-webkit-text-decoration-skip-ink: none;
+	text-decoration-skip-ink: none;
+	-webkit-text-decoration-skip: none;
+	text-decoration-skip: none;
+	color: var(--govuk-dark-blue);
+}
+
+.link-effects:visited {
+	color: var(--govuk-purple);
+	text-decoration-thickness: max(3px, .1875rem, .12em);
+}
+
+.link-effects:focus {
+	outline: 3px solid transparent;
+	color: var(--govuk-black);
+	background-color: var(--govuk-yellow);
+	box-shadow: 0 -2px var(--govuk-yellow),0 4px var(--govuk-black);
+	text-decoration: none;
+	-webkit-box-decoration-break: clone;
+	box-decoration-break: clone;
 }

--- a/src/lib/components/home_page_sections/FeaturedServices/FeaturedServicesCard.svelte
+++ b/src/lib/components/home_page_sections/FeaturedServices/FeaturedServicesCard.svelte
@@ -8,7 +8,7 @@
 <div id="outer">
 	<img src={servicesData.img_src} alt={servicesData.alt} />
 	<div id="inner">
-		<a href={servicesData.web_url} class="chevron-card">{servicesData.heading}</a>
+		<a class="featured-services-card__link link-effects link--large link--bold" href={servicesData.web_url} >{servicesData.heading}</a>
 		<p>{servicesData.content}</p>
 	</div>
 </div>
@@ -29,16 +29,29 @@
 		justify-content: center;
 	}
 
-	p {
-		padding-top: 7.5px;
-	}
-
-	a {
-		font-size: 18px;
-		font-weight: bold;
+	.featured-services-card__link {
 		text-decoration-thickness: 1px;
 		text-size-adjust: 100%;
-		text-underline-offset: 3.7872px;
+		text-underline-offset: 5px;
+		width: fit-content;
+	}
+
+	.featured-services-card__link:hover {
+		text-decoration-thickness: 3px;
+	}
+
+	.featured-services-card__link::after {
+		bottom: 0px;
+		content: '';
+		display: block;
+		left: 0px;
+		position: absolute;
+		right: 0px;
+		top: 0px;
+	}
+
+	p {
+		padding-top: 7.5px;
 	}
 
 	img {
@@ -50,24 +63,10 @@
 		margin-bottom: 10px;
 	}
 
-	a::after {
-		bottom: 0px;
-		content: '';
-		display: block;
-		left: 0px;
-		position: absolute;
-		right: 0px;
-		top: 0px;
-	}
-
 	@media screen and (min-width: 600px) {
 
 		#outer {
 			display: block;
-		}
-
-		a {
-			font-size: 24px;
 		}
 
 		img {

--- a/src/lib/components/home_page_sections/GovernmentActivity/BigNumberContainer.svelte
+++ b/src/lib/components/home_page_sections/GovernmentActivity/BigNumberContainer.svelte
@@ -1,42 +1,51 @@
-
 <script>
-  /**
+	/**
 	 * @type {any}
 	 */
-    export let num;
-    /**
+	export let num;
+	/**
 	 * @type {any}
 	 */
-    export let title;
+	export let title;
 </script>
 
-<div>
-  <a href="https://www.google.co.uk/" style="--num:'{num}'; --title:'{title}';"> <!-- for some weird reason the num and title variables needs to be wrapped in quotes again??? This is a hack to allow props to change the a::before/after content value using CSS variables. This is difficult because a::before/after is not written directly in the html and javascript variables can't be interpolated into css directly -->
-  </a>
+<div class="big-number-container">
+	<a
+		class="big-number-container__link link-effects link--bold"
+		href="https://www.google.co.uk/"
+		style="--num:'{num}'; --title:'{title}';"
+	>
+		<!-- for some weird reason the num and title variables needs to be wrapped in quotes again??? This is a hack to allow props to change the before/after content value using CSS variables. This is difficult because before/after is not written directly in the html and javascript variables can't be interpolated into css directly -->
+	</a>
 </div>
 
 <style>
+	/* fit content inside the div so whole area is a tag hyperlink */
+	.big-number-container {
+		width: fit-content;
+	}
 
-div {
-  /* fit content inside the div so whole area is a tag hyperlink */ 
-  width: fit-content;
-}
+	.big-number-container__link:not(:hover) {
+		text-decoration-line: none;
+	}
 
-a {
-  font-weight: bold;
-  color: #1d70b8;
-  text-decoration: none;
-}
+	/* Bug where hover effects aren't being applied from link-effects, could be issue using pseudo-elements. Duplicated code to make work. */
+	.big-number-container__link:hover {
+		text-decoration-thickness: max(3px, 0.1875rem, 0.12em);
+		-webkit-text-decoration-skip-ink: none;
+		text-decoration-skip-ink: none;
+		-webkit-text-decoration-skip: none;
+		text-decoration-skip: none;
+		color: var(--govuk-dark-blue);
+	}
 
-a::before {
-  content: var(--num);
-  font-size: 5rem;
-  display: block;
-}
+	.big-number-container__link::before {
+		content: var(--num);
+		font-size: 5rem;
+		display: block;
+	}
 
-a::after {
-  content: var(--title);
-}
-
+	.big-number-container__link::after {
+		content: var(--title);
+	}
 </style>
-

--- a/src/lib/components/home_page_sections/HomepageLinksAndSearch/HomepageLinksAndSearch.svelte
+++ b/src/lib/components/home_page_sections/HomepageLinksAndSearch/HomepageLinksAndSearch.svelte
@@ -16,7 +16,7 @@
 				<SectionHeading title="Popular on GOV.UK" />
 				<ul>
 					{#each homepageLinksAndSearchData.items as { content, web_url }}
-					<li><a href={web_url}>{content}</a></li>
+					<li><a class="link-effects link--medium link--bold" href={web_url}>{content}</a></li>
 					{/each}
 				</ul>
 			</div>
@@ -42,11 +42,6 @@
 
 	#links-and-search-container > div {
 		flex: 1;
-	}
-
-	a {
-		display: block;
-		font-weight: bold;
 	}
 
 	li {

--- a/src/lib/components/home_page_sections/MoreServices/MoreServices.svelte
+++ b/src/lib/components/home_page_sections/MoreServices/MoreServices.svelte
@@ -13,7 +13,7 @@
 		<SectionHeading title="More on GOV.UK" />
 		<ul id="more-services-list">
 			{#each moreServicesData.items.links as linksData}
-				<li><a href={linksData.web_url}>{linksData.content}</a></li>
+				<li><a class="link-effects link--medium" href={linksData.web_url}>{linksData.content}</a></li>
 			{/each}
 		</ul>
 	</WidthContainer>

--- a/src/lib/components/layout/Footer/Footer.svelte
+++ b/src/lib/components/layout/Footer/Footer.svelte
@@ -17,7 +17,9 @@
 				<SectionHeading title="Topics" />
 				<ul id="topics-list">
 					{#each footerData.topics.items.links as linksData}
-						<li><a href={linksData.web_url}>{linksData.heading}</a></li>
+						<li>
+							<a class="footer__link link-effects link--small" href={linksData.web_url}>{linksData.heading}</a>
+						</li>
 					{/each}
 				</ul>
 			</div>
@@ -25,8 +27,10 @@
 				<SectionHeading title="Government Activity" />
 				<ul id="government-activity-list">
 					{#each footerData.government_activity.items.links as linksData}
-					<li><a href={linksData.web_url}>{linksData.heading}</a></li>
-				{/each}
+						<li>
+							<a class="footer__link link-effects link--small" href={linksData.web_url}>{linksData.heading}</a>
+						</li>
+					{/each}
 				</ul>
 			</div>
 		</UnorderedListContainer>
@@ -39,6 +43,10 @@
 		border-top: 10px solid var(--govuk-blue);
 		background-color: var(--govuk-light-grey);
 		padding-top: 40px;
+	}
+
+	.footer__link:visited {
+		color: var(--govuk--black);
 	}
 
 	#government-activity-list {
@@ -58,10 +66,6 @@
 
 	li {
 		margin-bottom: 20px;
-	}
-
-	a {
-		font-size: 16px;
 	}
 
 	@media screen and (min-width: 600px) {

--- a/src/lib/components/layout/Footer/FooterMeta.svelte
+++ b/src/lib/components/layout/Footer/FooterMeta.svelte
@@ -5,14 +5,37 @@
 <div id="footer-meta">
 	<div id="footer-meta-text-container">
 		<ul id="footer-meta-list">
-			<li><a href='https://www.gov.uk/help'>Help</a></li>
-			<li><a href='https://www.gov.uk/help/privacy-notice'>Privacy</a></li>
-			<li><a href='https://www.gov.uk/help/cookies'>Cookies</a></li>
-			<li><a href='https://www.gov.uk/help/accessibility-statement'>Accessibility statement</a></li>
-			<li><a href='https://www.gov.uk/contact'>Contact</a></li>
-			<li><a href='https://www.gov.uk/help/terms-conditions'>Terms and conditions</a></li>
-			<li><a href='https://www.gov.uk/cymraeg'>Rhestr o Wasanaethau Cymraeg</a></li>
-			<li><a href='https://www.gov.uk/government/organisations/government-digital-service'>Government Digital Service</a></li>
+			<li><a class="footer__link link-effects link--small" href="https://www.gov.uk/help">Help</a></li>
+			<li>
+				<a class="footer__link link-effects link--small" href="https://www.gov.uk/help/privacy-notice">Privacy</a
+				>
+			</li>
+			<li>
+				<a class="footer__link link-effects link--small" href="https://www.gov.uk/help/cookies">Cookies</a>
+			</li>
+			<li>
+				<a class="footer__link link-effects link--small" href="https://www.gov.uk/help/accessibility-statement"
+					>Accessibility statement</a
+				>
+			</li>
+			<li><a class="footer__link link-effects link--small" href="https://www.gov.uk/contact">Contact</a></li>
+			<li>
+				<a class="footer__link link-effects link--small" href="https://www.gov.uk/help/terms-conditions"
+					>Terms and conditions</a
+				>
+			</li>
+			<li>
+				<a class="footer__link link-effects link--small" href="https://www.gov.uk/cymraeg"
+					>Rhestr o Wasanaethau Cymraeg</a
+				>
+			</li>
+			<li>
+				<a
+					class="footer__link link-effects link--small"
+					href="https://www.gov.uk/government/organisations/government-digital-service"
+					>Government Digital Service</a
+				>
+			</li>
 		</ul>
 		<svg
 			aria-hidden="true"
@@ -30,6 +53,7 @@
 		</svg>
 		<span id="footer-meta-license-description">
 			All content is available under the <a
+				class="footer__link link-effects link--small"
 				href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
 				>Open Government Licence v3.0</a
 			>, except where otherwise stated</span
@@ -38,6 +62,7 @@
 	<div id="footer-meta-img-container">
 		<img src={govCrest} alt="gov crest" />
 		<a
+			class="footer__link link-effects link--small"
 			href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/"
 			target="_blank"
 		>
@@ -47,6 +72,11 @@
 </div>
 
 <style>
+
+	.footer__link:visited {
+		color: var(--govuk--black);
+	}
+
 	#footer-meta {
 		display: flex;
 		flex-direction: column;
@@ -73,10 +103,6 @@
 		display: inline-block;
 		margin-right: 15px;
 		margin-bottom: 5px;
-	}
-
-	a {
-		font-size: 16px;
 	}
 
 	img {

--- a/src/lib/components/shared/ChevronCard.svelte
+++ b/src/lib/components/shared/ChevronCard.svelte
@@ -6,10 +6,10 @@
 	export let chevronData;
 </script>
 
-<li>
+<li class="chevron-card">
 	<div>
 		<h3>
-			<a href={chevronData.web_url} class="chevron-card">{chevronData.heading}</a>
+			<a class="chevron-card__link link-effects link--medium link--bold" href={chevronData.web_url}>{chevronData.heading}</a>
 		</h3>
 		<p>{chevronData.content}</p>
 	</div>
@@ -38,11 +38,7 @@
 		padding-bottom: 20px;
 	}
 
-	.chevron-card {
-		display: block;
-	}
-
-	.chevron-card::before {
+	.chevron-card__link::before {
 		content: '';
 		display: block;
 		height: 7px;
@@ -56,7 +52,7 @@
 	}
 
 	/* this hack makes the whole card clickable, stolen directly from gov.uk */
-	.chevron-card::after {
+	.chevron-card__link::after {
 		bottom: 0px;
 		content: '';
 		display: block;


### PR DESCRIPTION
This PR starts the implementation of a class-based design system for the styling of this web app, starting with `a` tags. Introducing a design system this way will improve the readability and maintainability of the CSS, as well as making it easier to debug. It adds numerous `.link` top-level utility classes in `app.css`, which are modified using the BEM naming convention (for example, `link--bold`, `link--small`, `link-effects`) to apply specific styling which is required by the components of the app. One caveat is that some components require custom, one-off styling which doesn't fall under this design system. In this case, custom CSS only scoped to the component is written to handle this one-off styling.

## This PR adds

- Top level CSS utility classes for `a` tags: link bold class, link font sizes classes and link pseudo-elements class
- Appropriate utility classes to all `a` elements in the markup of the components
- Custom CSS to override or add further `a` tag styling where necessary 
- Minor tweaks to component class names to follow BEM styling more closely when naming `a` tags specific to a component

## This PR removes

- All instances of global `a` selectors in `app.css` 
- Any component `a` tag styling using `a` selector